### PR TITLE
Pin version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:alpine
+FROM python:2-alpine3.11
 
 RUN pip install fonttools \
     && apk add --update git npm \
     && git clone https://github.com/kiliman/operator-mono-lig.git \
+    && cd operator-mono-lig \
+    && git checkout v2.2.8 \
     && apk del git
 
 WORKDIR /operator-mono-lig


### PR DESCRIPTION
The newer versions of the python image and the operator-mono-lig repo
cause build errors. Just locking the versions down here so that the
docker file builds.